### PR TITLE
Add initial step to build the map representation

### DIFF
--- a/code/raspberrypi/map/map.py
+++ b/code/raspberrypi/map/map.py
@@ -1,0 +1,89 @@
+import math
+
+from dolfin import Point, plot
+import mshr
+
+
+class Map():
+    def __init__(self, dimension, robot_radius):
+        # Correct the map size by the robot_radius
+        self.robot_radius = robot_radius
+        self.dimension = list(map(lambda x: x - robot_radius, dimension))
+
+        # Define the base rectangle.
+        self._map = mshr.Rectangle(
+            Point(robot_radius, robot_radius),
+            Point(self.dimension[0], self.dimension[1])
+        )
+
+        self._mesh2d = None
+
+    def add_circle_obstacle(self, p, radius, mirror=False):
+        points = [Point(p[0], p[1])]
+
+        # Replicate the circle on the other edge of the map.
+        if mirror:
+            points.append(Point(self.dimension[0] - p[0], p[1]))
+
+        for point in points:
+            self._map -= mshr.Circle(point, radius + self.robot_radius, 30)
+
+    def add_rectangle_obstacle(self, p1, p2, mirror=False):
+        self._map -= mshr.Rectangle(
+            self.__correct_point(Point(p1[0], p1[1]), inverse=-1),
+            self.__correct_point(Point(p2[0], p2[1]))
+        )
+
+        # Replicate the data the other side of the map.
+        if mirror:
+            p1bis = Point(
+                self.dimension[0] + self.robot_radius - p1[0] + self.robot_radius,
+                p1[1] - self.robot_radius
+            )
+            p2bis = Point(
+                self.dimension[0] + self.robot_radius - p2[0] - self.robot_radius,
+                p2[1] + self.robot_radius
+            )
+
+            self._map -= mshr.Rectangle(p2bis, p1bis)
+
+    # As dolfin and mshr don't support leaning rectangle, we build the
+    # rectangle giving him the point with the minimum y data,
+    # the absolute y size, the width, the angle with the 0 starting
+    # with the x axis.
+    # The accuracy give the number of rectangles we want to cut the
+    # leaning rectangle.
+    def add_leaning_rectangle_obstacle(self, p, height, width, angle,
+                                       mirror=False, accuracy=10):
+        height_chunck_size = height / (accuracy)
+
+        radian_angle = math.radians(angle)
+        for chunck in range(accuracy):
+            pos = chunck * height_chunck_size + height_chunck_size / 2
+            # Get the center of the little rectangle.
+            center_point = (pos * math.cos(radian_angle),
+                            pos * math.sin(radian_angle))
+
+            self.__build_rectangle_by_center(p, center_point,
+                                             height_chunck_size,
+                                             width, mirror)
+
+    def __build_rectangle_by_center(self, base_point, p, height, width,
+                                    mirror=False):
+        p1 = (base_point[0] + p[0] + width / 2,
+              base_point[1] + p[1] + height / 2)
+        p2 = (base_point[0] + p[0] - width / 2,
+              base_point[1] + p[1] - height / 2)
+        self.add_rectangle_obstacle(p1, p2, mirror)
+
+    def __correct_point(self, p, inverse=1):
+        return Point(p.x() + self.robot_radius*inverse,
+                     p.y() + self.robot_radius*inverse)
+
+    def build(self, accuracy=10):
+        self._mesh2d = mshr.generate_mesh(self._map, accuracy)
+
+    def display(self, accuracy=10):
+        if self._mesh2d is None:
+            self.build(accuracy)
+        plot(self._mesh2d, interactive=True)

--- a/code/raspberrypi/map/map_generator.py
+++ b/code/raspberrypi/map/map_generator.py
@@ -46,4 +46,4 @@ def build_map(removable=False):
 
 if __name__ == '__main__':
     m = build_map(removable=True)
-    m.display(accuracy=5)
+    m.display(accuracy=2)

--- a/code/raspberrypi/map/map_generator.py
+++ b/code/raspberrypi/map/map_generator.py
@@ -1,7 +1,7 @@
-from map import Map
+from mesh import Mesh
 
 def build_map(removable=False):
-    m = Map((300, 200), 17)
+    m = Mesh((300, 200), 17)
 
     # Define the start area.
     m.add_rectangle_obstacle((0, 36), (71, 38.2), mirror=True)

--- a/code/raspberrypi/map/map_generator.py
+++ b/code/raspberrypi/map/map_generator.py
@@ -1,0 +1,49 @@
+from map import Map
+
+def build_map(removable=False):
+    m = Map((300, 200), 17)
+
+    # Define the start area.
+    m.add_rectangle_obstacle((0, 36), (71, 38.2), mirror=True)
+
+    # Define the rockets distributor near the start area.
+    m.add_circle_obstacle((115, 4), 4, mirror=True)
+
+    # Define the rocket on the map side.
+    m.add_circle_obstacle((4, 135), 4, mirror=True)
+
+    # Define the little lunar rock reservoir.
+    m.add_circle_obstacle((71, 54), 8.5, mirror=True)
+
+    # Define the other little lunar rock reservoir.
+    m.add_circle_obstacle((115, 187), 8.5, mirror=True)
+
+    # Define the big lunar rock reservoir.
+    m.add_circle_obstacle((0, 200), 51, mirror=True)
+
+    # Define the side module collector.
+    m.add_rectangle_obstacle((0, 70), (8, 115), mirror=True)
+
+    # Define the big module collector:
+    # - the centrum
+    m.add_rectangle_obstacle((150, 115), (146, 200), mirror=True)
+    # - the side
+    m.add_leaning_rectangle_obstacle((93.44, 143.43), 80, 8, 45, mirror=True)
+    # - the circle connecting the module connector
+    m.add_circle_obstacle((150, 200), 20)
+
+    # The removable lunar module.
+    # The lunar module in the start is considered not here
+    # as we will obsiously take it.
+    if removable:
+        m.add_circle_obstacle((20, 60), 6.3, mirror=True)
+        m.add_circle_obstacle((100, 60), 6.3, mirror=True)
+        m.add_circle_obstacle((50, 110), 6.3, mirror=True)
+        m.add_circle_obstacle((90, 140), 6.3, mirror=True)
+        m.add_circle_obstacle((80, 1850), 6.3, mirror=True)
+
+    return m
+
+if __name__ == '__main__':
+    m = build_map(removable=True)
+    m.display(accuracy=5)

--- a/code/raspberrypi/map/mesh.py
+++ b/code/raspberrypi/map/mesh.py
@@ -4,7 +4,7 @@ from dolfin import Point, plot
 import mshr
 
 
-class Map():
+class Mesh():
     def __init__(self, dimension, robot_radius):
         # Correct the map size by the robot_radius
         self.robot_radius = robot_radius

--- a/code/raspberrypi/map/mesh.py
+++ b/code/raspberrypi/map/mesh.py
@@ -23,10 +23,10 @@ class Mesh():
 
         # Replicate the circle on the other edge of the map.
         if mirror:
-            points.append(Point(self.dimension[0] - p[0], p[1]))
+            points.append(Point(self.dimension[0] + self.robot_radius - p[0], p[1]))
 
         for point in points:
-            self._map -= mshr.Circle(point, radius + self.robot_radius, 30)
+            self._map -= mshr.Circle(point, radius + self.robot_radius, 5)
 
     def add_rectangle_obstacle(self, p1, p2, mirror=False):
         self._map -= mshr.Rectangle(


### PR DESCRIPTION
This first representation as "mesh" will be used later to create a graph. This graph will then be used to run an A* algorithm.
 
Here is a first look of the generated map representation:
![2017-03-09-21 06 12](https://cloud.githubusercontent.com/assets/14892338/23768399/236bce1c-050c-11e7-8c19-fa0754dc8a55.png)

One of the drawback of using the library is the installation of the ```dolfin``` and ```mshr``` library (in Archlinux it was a big pain in the ass) but it was the only library to build a proper mesh.